### PR TITLE
feat(aaa): StaticKeyVerifier — pre-distributed PEM JWT verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ pubspec.lock
 
 # git
 .egg-info/
+
+# Git worktrees (house rule: never commit)
+.worktrees/

--- a/packages/python-aaa/pyproject.toml
+++ b/packages/python-aaa/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguin-aaa"
-version = "0.1.0"
+version = "0.2.0"
 description = "PenguinTech Authentication, Authorization, and Accounting library"
 readme = "README.md"
 license = {text = "AGPL-3.0"}

--- a/packages/python-aaa/src/penguin_aaa/authn/__init__.py
+++ b/packages/python-aaa/src/penguin_aaa/authn/__init__.py
@@ -1,8 +1,13 @@
-"""Authentication subpackage — OIDC RP, OIDC Provider, SPIFFE, and types."""
+"""Authentication subpackage — OIDC RP, OIDC Provider, SPIFFE, static keys, and types."""
 
 from penguin_aaa.authn.oidc_provider import OIDCProvider, OIDCProviderConfig
 from penguin_aaa.authn.oidc_rp import OIDCRelyingParty, OIDCRPConfig
 from penguin_aaa.authn.spiffe import SPIFFEAuthenticator, SPIFFEConfig
+from penguin_aaa.authn.static_key import (
+    StaticKeyConfig,
+    StaticKeyVerifier,
+    load_key_from_env_or_file,
+)
 from penguin_aaa.authn.types import (
     ALLOWED_PROVIDER_ALGORITHMS,
     ALLOWED_RP_ALGORITHMS,
@@ -25,4 +30,7 @@ __all__ = [
     "OIDCProvider",
     "SPIFFEConfig",
     "SPIFFEAuthenticator",
+    "StaticKeyConfig",
+    "StaticKeyVerifier",
+    "load_key_from_env_or_file",
 ]

--- a/packages/python-aaa/src/penguin_aaa/authn/oidc_rp.py
+++ b/packages/python-aaa/src/penguin_aaa/authn/oidc_rp.py
@@ -125,6 +125,10 @@ class OIDCRelyingParty:
 
         return Claims.model_validate(payload)
 
+    async def verify_token(self, raw_token: str) -> Claims:
+        """Alias for validate_token — the ASGI OIDCAuthMiddleware calls verify_token()."""
+        return await self.validate_token(raw_token)
+
     def validate_state(self, returned_state: str, expected_state: str) -> bool:
         """
         Constant-time comparison of OAuth2 state parameters.

--- a/packages/python-aaa/src/penguin_aaa/authn/static_key.py
+++ b/packages/python-aaa/src/penguin_aaa/authn/static_key.py
@@ -1,0 +1,161 @@
+"""Static-key JWT verification — pre-distributed PEM public keys (no JWKS).
+
+For deployments where the signer's public key is distributed out of band
+(e.g. a Kubernetes Secret mounted into every verifier pod) instead of being
+fetched from an OIDC discovery/JWKS endpoint. Verifier services hold only the
+public key and can never mint tokens.
+
+Security contract (fail closed on every path):
+
+- asymmetric algorithms only (default ``ES256``/``RS256``); ``HS256``/``none``
+  are rejected, blocking the public-key-as-HMAC algorithm-confusion attack
+- ``iss`` and ``aud`` validated; ``exp``/``iat``/``tenant`` required
+- claims are validated through :class:`~penguin_aaa.authn.types.Claims`,
+  which mandates a non-empty ``tenant``
+- no public key configured → every verification fails
+
+The public key may be pinned in config or loaded at call time from an
+environment variable / file path (``load_key_from_env_or_file``), which
+supports key rotation without a process restart.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from penguin_aaa.authn.oidc_rp import _normalise_list_fields
+from penguin_aaa.authn.types import ALLOWED_RP_ALGORITHMS, MAX_TOKEN_SIZE, Claims
+
+logger = logging.getLogger(__name__)
+
+
+def load_key_from_env_or_file(env_var: str, file_env_var: str) -> str | None:
+    """Load a PEM key from an env var, or from the file a second env var names.
+
+    Args:
+        env_var: Environment variable holding the PEM content directly.
+        file_env_var: Environment variable holding a path to a PEM file.
+
+    Returns:
+        The PEM string, or None if neither source is available.
+    """
+    value = os.getenv(env_var)
+    if value:
+        return value
+
+    path = os.getenv(file_env_var)
+    if path and os.path.isfile(path):
+        with open(path, encoding="utf-8") as handle:
+            return handle.read().strip()
+
+    return None
+
+
+@dataclass(slots=True)
+class StaticKeyConfig:
+    """Configuration for a static-key JWT verifier.
+
+    Provide ``public_key`` to pin the key for the verifier's lifetime, or
+    leave it None to load from ``public_key_env`` / ``public_key_file_env``
+    on every verification (supports rotation without restart).
+    """
+
+    issuer: str
+    audience: str
+    public_key: str | None = None
+    public_key_env: str = "JWT_PUBLIC_KEY"
+    public_key_file_env: str = "JWT_PUBLIC_KEY_FILE"
+    algorithms: list[str] = field(default_factory=lambda: ["ES256", "RS256"])
+    required_claims: tuple[str, ...] = ("exp", "iat", "tenant")
+    clock_skew: timedelta = field(default_factory=lambda: timedelta(seconds=30))
+
+    def __post_init__(self) -> None:
+        if not self.issuer.strip():
+            raise ValueError("issuer must not be empty")
+        if not self.audience.strip():
+            raise ValueError("audience must not be empty")
+        for alg in self.algorithms:
+            if alg not in ALLOWED_RP_ALGORITHMS:
+                raise ValueError(
+                    f"Algorithm '{alg}' is not allowed. Permitted: {sorted(ALLOWED_RP_ALGORITHMS)}"
+                )
+
+
+class StaticKeyVerifier:
+    """Verify JWTs against a pre-distributed PEM public key."""
+
+    def __init__(self, config: StaticKeyConfig) -> None:
+        self._config = config
+
+    def _resolve_key(self) -> str | None:
+        if self._config.public_key:
+            return self._config.public_key
+        return load_key_from_env_or_file(
+            self._config.public_key_env, self._config.public_key_file_env
+        )
+
+    def validate_token(self, raw_token: str) -> Claims:
+        """Validate a raw JWT string and return its parsed claims.
+
+        Args:
+            raw_token: The encoded JWT string.
+
+        Returns:
+            Validated Claims instance (tenant guaranteed non-empty).
+
+        Raises:
+            ValueError: If no public key is configured, the token is oversized,
+                or required claims are missing/malformed.
+            jwt.PyJWTError: On signature, algorithm, expiry, issuer, or
+                audience failures.
+        """
+        if len(raw_token) > MAX_TOKEN_SIZE:
+            raise ValueError(f"Token exceeds maximum allowed size of {MAX_TOKEN_SIZE} bytes")
+
+        public_key = self._resolve_key()
+        if not public_key:
+            raise ValueError(
+                "No JWT public key configured "
+                f"(set {self._config.public_key_env} or {self._config.public_key_file_env})"
+            )
+
+        skew_seconds = int(self._config.clock_skew.total_seconds())
+        payload = jwt.decode(
+            raw_token,
+            public_key,
+            algorithms=self._config.algorithms,
+            audience=self._config.audience,
+            issuer=self._config.issuer,
+            leeway=skew_seconds,
+            options={"require": list(self._config.required_claims)},
+        )
+
+        # jwt.decode returns dict[str, Any]; normalise before pydantic validation
+        _normalise_list_fields(payload, ("aud", "scope", "roles", "teams"))
+
+        # JWT iat/exp are Unix timestamps (int) — convert for pydantic strict mode
+        for field_name in ("iat", "exp"):
+            val = payload.get(field_name)
+            if isinstance(val, (int, float)):
+                payload[field_name] = datetime.fromtimestamp(val, tz=UTC)
+
+        return Claims.model_validate(payload)
+
+    def verify_token(self, raw_token: str) -> Claims:
+        """Alias for validate_token — parity with OIDCRelyingParty."""
+        return self.validate_token(raw_token)
+
+    def verify_or_none(self, raw_token: str) -> Claims | None:
+        """Fail-closed convenience: return Claims, or None on ANY failure.
+
+        For callers that gate access with a boolean decision rather than
+        propagating auth errors (e.g. DNS zone checks).
+        """
+        try:
+            return self.validate_token(raw_token)
+        except Exception as exc:  # noqa: BLE001 — fail closed on any error
+            logger.warning("Static-key JWT verification failed: %s", exc)
+            return None

--- a/packages/python-aaa/src/penguin_aaa/middleware/asgi.py
+++ b/packages/python-aaa/src/penguin_aaa/middleware/asgi.py
@@ -40,10 +40,18 @@ class OIDCAuthMiddleware:
     payload. On failure, a 401 JSON response is returned immediately without
     invoking the wrapped application.
 
+    Optionally supports API-key verification as a fallback when a Bearer token
+    verification fails or when an API key is provided directly.
+
     Args:
         app: The wrapped ASGI application.
         rp: An OIDCRelyingParty instance used to verify tokens.
         public_paths: Paths that bypass authentication entirely.
+        api_key_verifier: Optional async callable that takes a raw credential
+            string and returns a claims/context object on success or raises
+            on failure. If None, only Bearer JWT authentication is supported.
+        api_key_header: Request header name for API keys (default: "x-api-key").
+            Only used if api_key_verifier is set.
     """
 
     def __init__(
@@ -51,10 +59,14 @@ class OIDCAuthMiddleware:
         app: ASGIApp,
         rp: Any,
         public_paths: set[str] | None = None,
+        api_key_verifier: Callable[[str], Awaitable[Any]] | None = None,
+        api_key_header: str = "x-api-key",
     ) -> None:
         self._app = app
         self._rp = rp
         self._public_paths = public_paths or set()
+        self._api_key_verifier = api_key_verifier
+        self._api_key_header = api_key_header
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] not in ("http", "websocket"):
@@ -68,20 +80,50 @@ class OIDCAuthMiddleware:
 
         headers = dict(scope.get("headers", []))
         auth = headers.get(b"authorization", b"").decode()
+        api_key = headers.get(self._api_key_header.encode(), b"").decode()
 
-        if not auth.startswith("Bearer "):
-            await _send_json_error(send, 401, "Missing or invalid Bearer token")
-            return
+        # Bearer path: try JWT verification, then fallback to verifier if set
+        if auth.startswith("Bearer "):
+            token = auth[7:]
+            try:
+                claims = await self._rp.verify_token(token)
+                scope.setdefault("state", {})["claims"] = claims
+                await self._app(scope, receive, send)
+                return
+            except Exception:
+                # Bearer JWT verification failed
+                if self._api_key_verifier:
+                    # Try treating the token as an API key
+                    try:
+                        result = await self._api_key_verifier(token)
+                        scope.setdefault("state", {})["claims"] = result
+                        await self._app(scope, receive, send)
+                        return
+                    except Exception:
+                        await _send_json_error(send, 401, "API key verification failed")
+                        return
+                else:
+                    # No verifier, so Bearer JWT failure is final
+                    await _send_json_error(send, 401, "Token verification failed")
+                    return
 
-        token = auth[7:]
-        try:
-            claims = await self._rp.verify_token(token)
-        except Exception:
-            await _send_json_error(send, 401, "Token verification failed")
-            return
+        # Raw-key / header path: only if verifier is set
+        if self._api_key_verifier:
+            # Pick candidate from api_key_header or raw auth (non-Bearer)
+            candidate = api_key or (auth if auth and not auth.startswith("Bearer ") else "")
+            if candidate:
+                try:
+                    result = await self._api_key_verifier(candidate)
+                    scope.setdefault("state", {})["claims"] = result
+                    await self._app(scope, receive, send)
+                    return
+                except Exception:
+                    await _send_json_error(send, 401, "API key verification failed")
+                    return
 
-        scope.setdefault("state", {})["claims"] = claims
-        await self._app(scope, receive, send)
+        # Nothing matched
+        await _send_json_error(send, 401, "Missing or invalid Bearer token")
+        return
 
 
 class SPIFFEAuthMiddleware:

--- a/packages/python-aaa/tests/test_asgi_middleware.py
+++ b/packages/python-aaa/tests/test_asgi_middleware.py
@@ -130,6 +130,165 @@ class TestOIDCAuthMiddleware:
         parsed = json.loads(body)
         assert "error" in parsed
 
+    # ---------------------------------------------------------------
+    # API-key verifier tests (backward compatibility + new feature)
+    # ---------------------------------------------------------------
+
+    async def _good_api_key_verifier(self, key: str) -> dict[str, Any]:
+        """Async verifier that accepts 'good-key' and returns a sentinel."""
+        if key != "good-key":
+            raise ValueError("Invalid API key")
+        return {"sub": "api-key-user", "via": "api_key"}
+
+    async def _bad_api_key_verifier(self, key: str) -> dict[str, Any]:
+        """Async verifier that rejects everything."""
+        raise ValueError("Invalid API key")
+
+    @pytest.mark.asyncio
+    async def test_no_verifier_preserves_backward_compatible_behavior(self):
+        """When api_key_verifier is None, behavior is byte-identical to before."""
+        rp = self._rp()
+        middleware = OIDCAuthMiddleware(_ok_app, rp)
+        # Test 1: missing auth → 401 with original message
+        scope = _http_scope()
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        body = messages[1]["body"]
+        parsed = json.loads(body)
+        assert parsed["error"] == "Missing or invalid Bearer token"
+        assert messages[0]["status"] == 401
+
+        # Test 2: non-Bearer auth → 401 with original message
+        messages, send = _make_send()
+        scope = _http_scope(headers=[(b"authorization", b"Basic dXNlcjpwYXNz")])
+        await middleware(scope, AsyncMock(), send)
+        body = messages[1]["body"]
+        parsed = json.loads(body)
+        assert parsed["error"] == "Missing or invalid Bearer token"
+        assert messages[0]["status"] == 401
+
+        # Test 3: Bearer token verified → passes
+        messages, send = _make_send()
+        scope = _http_scope(headers=[(b"authorization", b"Bearer valid-token")])
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_api_key_from_header_passes_through(self):
+        """API key from x-api-key header bypasses Bearer requirement."""
+        rp = self._rp()
+        middleware = OIDCAuthMiddleware(
+            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
+        )
+        scope = _http_scope(headers=[(b"x-api-key", b"good-key")])
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+        assert scope["state"]["claims"] == {"sub": "api-key-user", "via": "api_key"}
+
+    @pytest.mark.asyncio
+    async def test_raw_auth_header_without_bearer_prefix(self):
+        """Raw (non-Bearer) Authorization header is treated as API key."""
+        rp = self._rp()
+        middleware = OIDCAuthMiddleware(
+            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
+        )
+        scope = _http_scope(headers=[(b"authorization", b"good-key")])
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+        assert scope["state"]["claims"] == {"sub": "api-key-user", "via": "api_key"}
+
+    @pytest.mark.asyncio
+    async def test_bearer_jwt_fails_verifier_succeeds(self):
+        """When Bearer JWT fails, fallback to verifier if set."""
+        rp = self._rp(raises=True)
+        middleware = OIDCAuthMiddleware(
+            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
+        )
+        # Authorization: Bearer good-key (not a JWT, so rp.verify_token raises)
+        scope = _http_scope(headers=[(b"authorization", b"Bearer good-key")])
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+        assert scope["state"]["claims"] == {"sub": "api-key-user", "via": "api_key"}
+
+    @pytest.mark.asyncio
+    async def test_bad_api_key_returns_401(self):
+        """Bad API key returns 401 with API-key-specific error message."""
+        rp = self._rp()
+        middleware = OIDCAuthMiddleware(
+            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
+        )
+        scope = _http_scope(headers=[(b"x-api-key", b"bad-key")])
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 401
+        body = messages[1]["body"]
+        parsed = json.loads(body)
+        assert parsed["error"] == "API key verification failed"
+
+    @pytest.mark.asyncio
+    async def test_valid_bearer_jwt_skips_verifier(self):
+        """Valid Bearer JWT is accepted without consulting verifier."""
+        expected_claims = {"sub": "jwt-user", "scopes": ["read"]}
+        rp = self._rp(claims=expected_claims)
+        # verifier rejects everything, but should not be called
+        middleware = OIDCAuthMiddleware(
+            _ok_app, rp, api_key_verifier=self._bad_api_key_verifier
+        )
+        scope = _http_scope(headers=[(b"authorization", b"Bearer valid-jwt")])
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+        # Claims from JWT, not from verifier
+        assert scope["state"]["claims"] == expected_claims
+
+    @pytest.mark.asyncio
+    async def test_custom_api_key_header(self):
+        """api_key_header parameter customizes the header name."""
+        rp = self._rp()
+        middleware = OIDCAuthMiddleware(
+            _ok_app,
+            rp,
+            api_key_verifier=self._good_api_key_verifier,
+            api_key_header="authorization-key",
+        )
+        scope = _http_scope(headers=[(b"authorization-key", b"good-key")])
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+        assert scope["state"]["claims"] == {"sub": "api-key-user", "via": "api_key"}
+
+    @pytest.mark.asyncio
+    async def test_api_key_header_takes_precedence_over_raw_auth(self):
+        """When both api_key_header and raw auth are present, header is tried first."""
+        call_count = 0
+        original_verifier = self._good_api_key_verifier
+
+        async def tracking_verifier(key: str) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            return await original_verifier(key)
+
+        rp = self._rp()
+        middleware = OIDCAuthMiddleware(
+            _ok_app, rp, api_key_verifier=tracking_verifier
+        )
+        # Both api_key_header and raw auth present; api_key_header should be used
+        scope = _http_scope(
+            headers=[
+                (b"x-api-key", b"good-key"),
+                (b"authorization", b"bad-key"),
+            ]
+        )
+        messages, send = _make_send()
+        await middleware(scope, AsyncMock(), send)
+        assert messages[0]["status"] == 200
+        assert call_count == 1
+        # Should have passed with good-key (from header)
+        assert scope["state"]["claims"]["via"] == "api_key"
+
 
 # ---------------------------------------------------------------------------
 # SPIFFEAuthMiddleware

--- a/packages/python-aaa/tests/test_asgi_middleware.py
+++ b/packages/python-aaa/tests/test_asgi_middleware.py
@@ -177,9 +177,7 @@ class TestOIDCAuthMiddleware:
     async def test_api_key_from_header_passes_through(self):
         """API key from x-api-key header bypasses Bearer requirement."""
         rp = self._rp()
-        middleware = OIDCAuthMiddleware(
-            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
-        )
+        middleware = OIDCAuthMiddleware(_ok_app, rp, api_key_verifier=self._good_api_key_verifier)
         scope = _http_scope(headers=[(b"x-api-key", b"good-key")])
         messages, send = _make_send()
         await middleware(scope, AsyncMock(), send)
@@ -190,9 +188,7 @@ class TestOIDCAuthMiddleware:
     async def test_raw_auth_header_without_bearer_prefix(self):
         """Raw (non-Bearer) Authorization header is treated as API key."""
         rp = self._rp()
-        middleware = OIDCAuthMiddleware(
-            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
-        )
+        middleware = OIDCAuthMiddleware(_ok_app, rp, api_key_verifier=self._good_api_key_verifier)
         scope = _http_scope(headers=[(b"authorization", b"good-key")])
         messages, send = _make_send()
         await middleware(scope, AsyncMock(), send)
@@ -203,9 +199,7 @@ class TestOIDCAuthMiddleware:
     async def test_bearer_jwt_fails_verifier_succeeds(self):
         """When Bearer JWT fails, fallback to verifier if set."""
         rp = self._rp(raises=True)
-        middleware = OIDCAuthMiddleware(
-            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
-        )
+        middleware = OIDCAuthMiddleware(_ok_app, rp, api_key_verifier=self._good_api_key_verifier)
         # Authorization: Bearer good-key (not a JWT, so rp.verify_token raises)
         scope = _http_scope(headers=[(b"authorization", b"Bearer good-key")])
         messages, send = _make_send()
@@ -217,9 +211,7 @@ class TestOIDCAuthMiddleware:
     async def test_bad_api_key_returns_401(self):
         """Bad API key returns 401 with API-key-specific error message."""
         rp = self._rp()
-        middleware = OIDCAuthMiddleware(
-            _ok_app, rp, api_key_verifier=self._good_api_key_verifier
-        )
+        middleware = OIDCAuthMiddleware(_ok_app, rp, api_key_verifier=self._good_api_key_verifier)
         scope = _http_scope(headers=[(b"x-api-key", b"bad-key")])
         messages, send = _make_send()
         await middleware(scope, AsyncMock(), send)
@@ -234,9 +226,7 @@ class TestOIDCAuthMiddleware:
         expected_claims = {"sub": "jwt-user", "scopes": ["read"]}
         rp = self._rp(claims=expected_claims)
         # verifier rejects everything, but should not be called
-        middleware = OIDCAuthMiddleware(
-            _ok_app, rp, api_key_verifier=self._bad_api_key_verifier
-        )
+        middleware = OIDCAuthMiddleware(_ok_app, rp, api_key_verifier=self._bad_api_key_verifier)
         scope = _http_scope(headers=[(b"authorization", b"Bearer valid-jwt")])
         messages, send = _make_send()
         await middleware(scope, AsyncMock(), send)
@@ -272,9 +262,7 @@ class TestOIDCAuthMiddleware:
             return await original_verifier(key)
 
         rp = self._rp()
-        middleware = OIDCAuthMiddleware(
-            _ok_app, rp, api_key_verifier=tracking_verifier
-        )
+        middleware = OIDCAuthMiddleware(_ok_app, rp, api_key_verifier=tracking_verifier)
         # Both api_key_header and raw auth present; api_key_header should be used
         scope = _http_scope(
             headers=[

--- a/packages/python-aaa/tests/test_oidc_rp.py
+++ b/packages/python-aaa/tests/test_oidc_rp.py
@@ -163,9 +163,7 @@ class TestOIDCRelyingPartyVerifyToken:
         rp = OIDCRelyingParty(config)
 
         sentinel_claims = MagicMock()
-        with patch.object(
-            rp, "validate_token", return_value=sentinel_claims
-        ) as mock_validate:
+        with patch.object(rp, "validate_token", return_value=sentinel_claims) as mock_validate:
             mock_validate.return_value = sentinel_claims
             result = await rp.verify_token("some-raw-token")
 

--- a/packages/python-aaa/tests/test_oidc_rp.py
+++ b/packages/python-aaa/tests/test_oidc_rp.py
@@ -156,6 +156,23 @@ class TestOIDCRelyingPartyValidateToken:
             await rp.validate_token(oversized)
 
 
+class TestOIDCRelyingPartyVerifyToken:
+    @pytest.mark.asyncio
+    async def test_verify_token_delegates_to_validate_token(self):
+        config = _make_rp_config()
+        rp = OIDCRelyingParty(config)
+
+        sentinel_claims = MagicMock()
+        with patch.object(
+            rp, "validate_token", return_value=sentinel_claims
+        ) as mock_validate:
+            mock_validate.return_value = sentinel_claims
+            result = await rp.verify_token("some-raw-token")
+
+        mock_validate.assert_awaited_once_with("some-raw-token")
+        assert result is sentinel_claims
+
+
 class TestOIDCRelyingPartyStateHelpers:
     def test_generate_state_is_urlsafe_string(self):
         config = _make_rp_config()

--- a/packages/python-aaa/tests/test_static_key.py
+++ b/packages/python-aaa/tests/test_static_key.py
@@ -26,10 +26,14 @@ def _gen_es256_pem() -> tuple[str, str]:
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
-    pub = key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
+    pub = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
     return priv, pub
 
 

--- a/packages/python-aaa/tests/test_static_key.py
+++ b/packages/python-aaa/tests/test_static_key.py
@@ -1,0 +1,187 @@
+"""Tests for static-key JWT verification (penguin_aaa.authn.static_key)."""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from penguin_aaa.authn.static_key import (
+    StaticKeyConfig,
+    StaticKeyVerifier,
+    load_key_from_env_or_file,
+)
+from penguin_aaa.authn.types import Claims
+
+ISSUER = "squawk-manager"
+AUDIENCE = "squawk"
+
+
+def _gen_es256_pem() -> tuple[str, str]:
+    key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    priv = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub
+
+
+@pytest.fixture(scope="module")
+def keypair() -> tuple[str, str]:
+    return _gen_es256_pem()
+
+
+def _payload(**overrides: object) -> dict:
+    now = datetime.now(UTC)
+    payload: dict = {
+        "sub": "42",
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "tenant": "default",
+        "scope": "servers:read servers:write",
+        "iat": now,
+        "exp": now + timedelta(minutes=15),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _token(private_pem: str, algorithm: str = "ES256", **overrides: object) -> str:
+    return jwt.encode(_payload(**overrides), private_pem, algorithm=algorithm)
+
+
+def _verifier(public_pem: str, **config_overrides: object) -> StaticKeyVerifier:
+    config = StaticKeyConfig(
+        issuer=ISSUER, audience=AUDIENCE, public_key=public_pem, **config_overrides
+    )
+    return StaticKeyVerifier(config)
+
+
+class TestValidTokens:
+    def test_valid_es256_token_returns_claims(self, keypair):
+        priv, pub = keypair
+        claims = _verifier(pub).validate_token(_token(priv))
+        assert isinstance(claims, Claims)
+        assert claims.sub == "42"
+        assert claims.tenant == "default"
+        assert claims.scope == ["servers:read", "servers:write"]
+
+    def test_verify_token_alias(self, keypair):
+        priv, pub = keypair
+        assert _verifier(pub).verify_token(_token(priv)).sub == "42"
+
+    def test_verify_or_none_success(self, keypair):
+        priv, pub = keypair
+        assert _verifier(pub).verify_or_none(_token(priv)) is not None
+
+
+class TestFailClosed:
+    def test_wrong_key_rejected(self, keypair):
+        _priv, pub = keypair
+        attacker_priv, _ = _gen_es256_pem()
+        with pytest.raises(jwt.InvalidSignatureError):
+            _verifier(pub).validate_token(_token(attacker_priv))
+
+    def test_hs256_rejected(self, keypair):
+        """Algorithm confusion: HS256 never passes the asymmetric allowlist."""
+        _priv, pub = keypair
+        forged = jwt.encode(_payload(), "attacker-secret", algorithm="HS256")
+        with pytest.raises(jwt.PyJWTError):
+            _verifier(pub).validate_token(forged)
+
+    def test_hs256_not_configurable(self):
+        with pytest.raises(ValueError, match="not allowed"):
+            StaticKeyConfig(issuer=ISSUER, audience=AUDIENCE, algorithms=["HS256"])
+
+    def test_expired_rejected(self, keypair):
+        priv, pub = keypair
+        now = datetime.now(UTC)
+        expired = _token(priv, iat=now - timedelta(hours=2), exp=now - timedelta(hours=1))
+        with pytest.raises(jwt.ExpiredSignatureError):
+            _verifier(pub).validate_token(expired)
+
+    def test_wrong_audience_rejected(self, keypair):
+        priv, pub = keypair
+        with pytest.raises(jwt.InvalidAudienceError):
+            _verifier(pub).validate_token(_token(priv, aud="other-service"))
+
+    def test_wrong_issuer_rejected(self, keypair):
+        priv, pub = keypair
+        with pytest.raises(jwt.InvalidIssuerError):
+            _verifier(pub).validate_token(_token(priv, iss="evil-issuer"))
+
+    def test_missing_tenant_rejected(self, keypair):
+        priv, pub = keypair
+        payload = _payload()
+        del payload["tenant"]
+        token = jwt.encode(payload, priv, algorithm="ES256")
+        with pytest.raises(jwt.MissingRequiredClaimError):
+            _verifier(pub).validate_token(token)
+
+    def test_empty_tenant_rejected(self, keypair):
+        priv, pub = keypair
+        with pytest.raises(ValueError):
+            _verifier(pub).validate_token(_token(priv, tenant="   "))
+
+    def test_no_key_configured_raises(self, keypair, monkeypatch):
+        priv, _pub = keypair
+        monkeypatch.delenv("JWT_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("JWT_PUBLIC_KEY_FILE", raising=False)
+        verifier = StaticKeyVerifier(StaticKeyConfig(issuer=ISSUER, audience=AUDIENCE))
+        with pytest.raises(ValueError, match="No JWT public key configured"):
+            verifier.validate_token(_token(priv))
+
+    def test_oversized_token_rejected(self, keypair):
+        _priv, pub = keypair
+        with pytest.raises(ValueError, match="maximum allowed size"):
+            _verifier(pub).validate_token("x" * 9000)
+
+    def test_verify_or_none_returns_none_on_failure(self, keypair):
+        _priv, pub = keypair
+        attacker_priv, _ = _gen_es256_pem()
+        assert _verifier(pub).verify_or_none(_token(attacker_priv)) is None
+        assert _verifier(pub).verify_or_none("not-a-jwt") is None
+
+
+class TestKeyLoading:
+    def test_load_from_env(self, keypair, monkeypatch):
+        _priv, pub = keypair
+        monkeypatch.setenv("JWT_PUBLIC_KEY", pub)
+        assert load_key_from_env_or_file("JWT_PUBLIC_KEY", "JWT_PUBLIC_KEY_FILE") == pub
+
+    def test_load_from_file(self, keypair, monkeypatch, tmp_path):
+        _priv, pub = keypair
+        key_file = tmp_path / "jwt-public-key.pem"
+        key_file.write_text(pub + "\n")
+        monkeypatch.delenv("JWT_PUBLIC_KEY", raising=False)
+        monkeypatch.setenv("JWT_PUBLIC_KEY_FILE", str(key_file))
+        loaded = load_key_from_env_or_file("JWT_PUBLIC_KEY", "JWT_PUBLIC_KEY_FILE")
+        assert loaded == pub.strip()
+
+    def test_load_returns_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("JWT_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("JWT_PUBLIC_KEY_FILE", raising=False)
+        assert load_key_from_env_or_file("JWT_PUBLIC_KEY", "JWT_PUBLIC_KEY_FILE") is None
+
+    def test_call_time_key_rotation(self, keypair, monkeypatch):
+        """With no pinned key, the env key is read on every verification."""
+        priv1, pub1 = keypair
+        priv2, pub2 = _gen_es256_pem()
+
+        verifier = StaticKeyVerifier(StaticKeyConfig(issuer=ISSUER, audience=AUDIENCE))
+
+        monkeypatch.setenv("JWT_PUBLIC_KEY", pub1)
+        assert verifier.verify_or_none(_token(priv1)) is not None
+        assert verifier.verify_or_none(_token(priv2)) is None
+
+        # Rotate: same verifier instance picks up the new key without restart.
+        monkeypatch.setenv("JWT_PUBLIC_KEY", pub2)
+        assert verifier.verify_or_none(_token(priv2)) is not None
+        assert verifier.verify_or_none(_token(priv1)) is None


### PR DESCRIPTION
## Summary
- New `penguin_aaa.authn.static_key` module: static-key JWT verifier (pre-distributed PEM verification)
- `OIDCAuthMiddleware` gains an optional, backward-compatible `api_key_verifier` hook (enables `wa-`/`x-api-key` auth flows in consumers like WaddleAI)
- `OIDCRelyingParty.verify_token` async alias for ASGI middleware
- **Releases penguin-aaa 0.2.0**: version bumped in this PR; after merge, tag `penguin-aaa-v0.2.0` triggers PyPI trusted publishing via `publish.yml`

## Consumers
WaddleAI PR waddleai#50 depends on this release — its API-key auth currently only passes against a local editable install.

## Test plan
- `pytest packages/python-aaa/tests`: **277 passed**
- `ruff check` + `ruff format --check`: clean
- `bandit`: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
