### PR TITLE
[Chore] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for penguintechinc/penguin-libs
+#
+# The org default-branch ruleset sets require_code_owner_review, so every PR
+# into the default branch needs an approving review from someone listed here.
+#
+# Two owners deliberately. GitHub forbids approving your own PR, so a single
+# owner who also writes most of the PRs would make every one of them
+# unmergeable except by admin bypass — which would defeat the review
+# requirement rather than satisfy it.
+
+*   @PenguinzTech @Chromeninja


### PR DESCRIPTION
The org default-branch ruleset sets `require_code_owner_review`, so every PR into `main` needs an approving review from someone in CODEOWNERS. This repo has no CODEOWNERS file, which means that requirement currently matches nobody — adding one here.

Owner line:
```
*   @PenguinzTech @Chromeninja
```

Two owners deliberately: GitHub forbids self-approval, so a single owner who also writes most PRs would make them unmergeable except by admin bypass.

Added via the GitHub Contents API rather than a local branch — the local checkout on this machine has unrelated in-progress feature work (staged renames/adds/deletes in packages/rust-licensing, unstaged changes in packages/python-aaa) that shouldn't be touched.

## Summary by Sourcery

Chores:
- Introduce a .github/CODEOWNERS file assigning repository ownership to specific maintainers.