### PR TITLE
fix(ci): bump gh-action-pypi-publish to v1.14.2 (Metadata-Version 2.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,7 +180,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-libs/dist/
 
@@ -236,7 +236,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-licensing/dist/
 
@@ -292,7 +292,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-secrets/dist/
 
@@ -348,7 +348,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-utils/dist/
 
@@ -503,7 +503,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-aaa/dist/
 
@@ -559,7 +559,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-dal/dist/
 
@@ -770,7 +770,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-pytest/dist/
 
@@ -826,7 +826,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-email/dist/
 
@@ -882,7 +882,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-limiter/dist/
 
@@ -938,7 +938,7 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/python-rpc/dist/
 


### PR DESCRIPTION
## Problem

The `penguin-dal-v0.4.0` tag fired `publish.yml`, the job ran, and the upload failed:

```
InvalidDistribution: Metadata is missing required fields: Name, Version.
Make sure the distribution includes the files where those fields are
specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2
```

`pypa/gh-action-pypi-publish` was pinned at **v1.8.12**, whose bundled twine parses `Metadata-Version` only up to **2.2**. Current setuptools emits **2.4**, so the action cannot read the wheel's `Name`/`Version` and aborts *before* authenticating.

The job's own `twine check dist/*` step passes, because that twine is installed fresh in the runner — only the twine vendored inside the pinned action is stale.

penguin-dal 0.3.0 published fine on 2026-04-07 because setuptools had not yet moved to 2.4. The pin rotted silently rather than breaking when it was set.

## Fix

Bump to v1.14.2 (`dc37677b2e1c63e2034f94d8a5b11f265b73ba33`), SHA-pinned per house policy.

## Blast radius

All **10** Python publish jobs shared the broken pin, so this plausibly accounts for a large share of the repo's unpublished Python packages — not just dal. Auth is unaffected: no password secret is passed, so OIDC trusted publishing continues to be used (the same mechanism that shipped 0.3.0).

Nothing was uploaded during the failed run, so `penguin-dal` 0.4.0 remains free on PyPI and is retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)