### PR TITLE
fix(ci): correct penguin-limiter publish job's GitHub environment name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -848,7 +848,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: pypi-limiter
+    # The actually-configured GitHub environment is "py-limiter" (created
+    # 2026-03-29, no other "pypi-limiter" environment exists) — likely what
+    # PyPI's trusted-publisher config for this not-yet-published project
+    # already references. "pypi-limiter" here was a copy-paste mismatch
+    # from the sibling pypi-aaa/pypi-dal/etc. jobs, never corrected.
+    environment: py-limiter
     if: |
       github.event_name == 'workflow_dispatch' &&
       (github.event.inputs.package == 'python-limiter' || github.event.inputs.package == 'all') ||


### PR DESCRIPTION
## Summary

\`publish-python-limiter\` referenced \`environment: pypi-limiter\`, which doesn't exist anywhere in this repo. The environment actually configured (created 2026-03-29, no protection rules, no other candidates) is \`py-limiter\` — a copy-paste mismatch from the sibling \`pypi-aaa\`/\`pypi-dal\`/etc. jobs that was never corrected.

If PyPI's trusted-publisher configuration for this not-yet-published project scopes trust to a specific GitHub environment name (the standard mechanism), this mismatch would make every publish attempt fail with an environment-claim mismatch — discovered while preparing to cut the first \`penguin-limiter-v0.1.0\` release.

## Verification

- Confirmed via \`gh api .../environments\`: \`py-limiter\` exists, \`pypi-limiter\` returns 404
- Ran the package's full test suite locally against this release branch: 106 passed, 7 skipped
- \`python -m build\` + \`twine check dist/*\` both clean

## Test plan

- [x] Environment name in workflow now matches the only environment that exists
- [x] No other changes — single-line fix + explanatory comment